### PR TITLE
JZ changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,19 @@
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-recipes</artifactId>
 			<version>4.0.1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
-
+		<dependency>
+			<groupId>org.apache.zookeeper</groupId>
+			<artifactId>zookeeper</artifactId>
+			<version>3.4.5</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/locking/BaseLockService.java
+++ b/src/main/java/com/example/locking/BaseLockService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -83,7 +84,7 @@ public abstract class BaseLockService {
     @PostConstruct
     public void init() {
         log.info("Stating initialization of the Lock Service");
-        locks = new HashMap<>();
+        locks = new ConcurrentHashMap<>();
         client = createClient();
         client.start();
 

--- a/src/main/java/com/example/locking/BaseLockService.java
+++ b/src/main/java/com/example/locking/BaseLockService.java
@@ -152,9 +152,6 @@ public abstract class BaseLockService {
             InterProcessMutex lock = lockHandle.getMutex();
             if (lock != null) {
                 lock.release();
-                client.delete()
-                        .deletingChildrenIfNeeded()
-                        .forPath(ZKPaths.makePath(getLockPath(), String.valueOf(lockHandle.getId())));
                 success = true;
             }
         } catch (Exception e) {


### PR DESCRIPTION
I found a number of issues in the https://github.com/shaunmccready/locking-issue[Locking Issue Example][1] you sent. It could be these are particular to the example but if these are also in your code it will explain the problems you're seeing.

 1. The Maven POM is incorrectly specified. Curator needs to know that it's in ZK 3.4.x compatibility mode the way to do this is [described here][2]. The Tl;DR is exclude Zookeeper from the Curator dependency and add a direct dependency to Zookeeper 3.4.x.
 2. The `locks` field in `BaseLockService` should be a `ConcurrentHashMap`
 3. `BaseLockService#unlock` is trying to clean up the lock path by calling `client.delete()...`. This cannot work. There is an inherent race in this kind of code and is why Curator has the "Reaper" classes and also why I pushed Container Nodes into Zookeeper 3.5.x. Notice that it is this line of code that's producing the `NoNode` exception and not the Curator lock code. I suggest you get rid of that code and just not worry about it or move to Zookeeper 3.5.x.
 4. I don't think `BaseLockService` should keep re-creating the `InterProcessMutex`. It should keep a map of them or something.

When I applied 1-3 above the test passes successfully.

  [1]: https://github.com/shaunmccready/locking-issue
  [2]: http://curator.apache.org/zk-compatibility.html